### PR TITLE
Don't try to go back to previous move when point is in header

### DIFF
--- a/pgn-mode.el
+++ b/pgn-mode.el
@@ -480,7 +480,7 @@ With numeric prefix ARG, move ARG moves backward."
           (thumb (point)))
       (when (or (looking-at "[^\n]*\\]")
                 (and (looking-at "\\s-*$") (looking-back "\\]\\s-*" 10)))
-        (re-search-backward "\n\n" nil t))
+        (error "No more moves."))
       (dotimes (counter arg)
         (when (pgn-mode-looking-at-legal-move)
           (setq thumb (point))


### PR DESCRIPTION
There is no previous move at this location.

This code is a remnant. The first version of these defuns allowed next/prev move to traverse between games.