### PR TITLE
Tighten pgn-mode-looking-at-legal-move

### DIFF
--- a/pgn-mode.el
+++ b/pgn-mode.el
@@ -258,8 +258,10 @@
 (defun pgn-mode-looking-at-legal-move ()
   "Whether the point is looking at a legal SAN chess move.
 
-Leading move numbers are allowed, and ignored."
-  (looking-at-p "[0-9.…\s-]*\\<\\([RNBQK][a-h]?[1-8]?x?[a-h][1-8]\\|[a-h]x?[1-8]=?[RNBQ]?\\|O-O\\|O-O-O\\)\\(\\+\\+?\\|#\\)?"))
+Leading move numbers, punctuation and spaces are allowed, and ignored."
+  (let ((inhibit-changing-match-data t))
+    (and (looking-at-p "[ \t]*[0-9]*[.…\s-]*\\<\\([RNBQK][a-h]?[1-8]?x?[a-h][1-8]\\|[a-h]x?[1-8]=?[RNBQ]?\\|O-O\\|O-O-O\\)\\(\\+\\+?\\|#\\)?")
+         (not (looking-back "[A-Za-z]" 1)))))
 
 (defun pgn-mode-game-start-position (&optional pos)
   "Start position for the PGN game which contains position POS.


### PR DESCRIPTION
Specifically, in mid-SAN-move, there could be false positives looking forward over a trailing number.