### PR TITLE
Restore missing python imports

### DIFF
--- a/pygn_handler.py
+++ b/pygn_handler.py
@@ -27,6 +27,9 @@ import sys
 import argparse
 import textwrap
 import signal
+import io
+import re
+
 import chess.pgn
 import chess.svg
 


### PR DESCRIPTION
restore `io` and `re` python imports which were lost when resolving merge conflicts

~HOLD this for a rebase after #23 is merged.~